### PR TITLE
fix : ZeroDivisionError 해결

### DIFF
--- a/opencv/findball.py
+++ b/opencv/findball.py
@@ -62,7 +62,7 @@ while True:
         c = max(cnts, key=cv2.contourArea)
         ((x, y), radius) = cv2.minEnclosingCircle(c)
         M = cv2.moments(c)
-        #if M["m00"] == 0 : break
+        if M["m00"] == 0 : M["m00"] = 1
         center = (int(M["m10"] / M["m00"]), int(M["m01"] / M["m00"]))
 
         if radius > golfball_size:


### PR DESCRIPTION
- 문제 : 노란색 공이 사라지면 ZeroDivisionError 발생
- 해결 : findball.py에 if M["m00"] == 0 : break 부분 삭제하는 것이 아닌, `M["m00"] != 0` 인 경우에 작동하도록 코드를 수정하였습니다.

![image](https://github.com/TECH-PIONEERS/capstone-project/assets/64563859/5d5d76f6-3d03-452f-a332-67c862c4efdd)

